### PR TITLE
Fixes critical dimension bug

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,29 @@
+# eclipse
+bin
+*.launch
+.settings
+.metadata
+.classpath
+.project
+
+# idea
+out
+*.ipr
+*.iws
+*.iml
+.idea
+
+# gradle
+build
+.gradle
+
+# other
+eclipse
+run
+
+# Files from Forge MDK
+forge*changelog.txt
+gradle/wrapper/gradle-wrapper.jar
+gradle/wrapper/gradle-wrapper.properties
+gradlew
+gradlew.bat

--- a/src/main/java/melonslise/spook/common/capability/Sanity.java
+++ b/src/main/java/melonslise/spook/common/capability/Sanity.java
@@ -40,7 +40,7 @@ public class Sanity implements ISanity
 
 		if(oldSanity != this.sanity && this.player instanceof ServerPlayer player)
 		{
-			if(this.sanity > 90f)
+			if(this.sanity > 90f && this.player.level.dimension().toString().contains("spook:fogworld"))
 			{
 				player.teleportTo(player.server.getLevel(Level.OVERWORLD), player.getX(), player.getY(), player.getZ(), player.getYRot(), player.getXRot());
 			}


### PR DESCRIPTION
Whenever a player is in a dimension other than the overworld and has a sanity change that ends up above 90%, they would teleport to the overworld as if it were the mist world. Not just while in the mist world.
